### PR TITLE
Add admin dashboard and management features

### DIFF
--- a/env.example
+++ b/env.example
@@ -2,6 +2,7 @@
 # Get these values from your Supabase project settings
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url_here
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
 
 # Optional: Database URL for direct database access (if needed)
 # SUPABASE_DB_URL=postgresql://postgres:[password]@db.[project-ref].supabase.co:5432/postgres

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useAppStore } from '@/lib/store'
+import AdminDashboard from '@/components/AdminDashboard'
+
+export default function AdminPage() {
+  const { user, userOrganization } = useAppStore()
+  const [orgId, setOrgId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (userOrganization?.organization_id) {
+      setOrgId(userOrganization.organization_id)
+    }
+  }, [userOrganization])
+
+  if (!user || !orgId) return null
+
+  return <AdminDashboard organizationId={orgId} />
+}

--- a/src/app/api/delete-user/route.ts
+++ b/src/app/api/delete-user/route.ts
@@ -1,0 +1,38 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabaseAdmin'
+
+export async function POST(req: Request) {
+  const { userId } = await req.json()
+  if (!userId) {
+    return NextResponse.json({ error: 'Missing userId' }, { status: 400 })
+  }
+
+  const supabase = createRouteHandlerClient({ cookies })
+  const {
+    data: { session }
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: userData } = await supabase
+    .from('users')
+    .select('role')
+    .eq('id', session.user.id)
+    .single()
+
+  if (userData?.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { error } = await supabaseAdmin.auth.admin.deleteUser(userId)
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/invite-user/route.ts
+++ b/src/app/api/invite-user/route.ts
@@ -1,0 +1,46 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabaseAdmin'
+
+export async function POST(req: Request) {
+  const { email, organizationId } = await req.json()
+  if (!email || !organizationId) {
+    return NextResponse.json({ error: 'Missing parameters' }, { status: 400 })
+  }
+
+  const supabase = createRouteHandlerClient({ cookies })
+  const {
+    data: { session }
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Check that current user is admin
+  const { data: userData } = await supabase
+    .from('users')
+    .select('role')
+    .eq('id', session.user.id)
+    .single()
+
+  if (userData?.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { data: invite, error } = await supabaseAdmin.auth.admin.inviteUserByEmail(
+    email
+  )
+
+  if (error || !invite.user) {
+    return NextResponse.json({ error: error?.message || 'Invite failed' }, { status: 500 })
+  }
+
+  await supabaseAdmin
+    .from('users')
+    .update({ organization_id: organizationId })
+    .eq('id', invite.user.id)
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/update-idea-status/route.ts
+++ b/src/app/api/update-idea-status/route.ts
@@ -1,0 +1,40 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+export async function POST(req: Request) {
+  const { ideaId, status } = await req.json()
+  if (!ideaId || !status) {
+    return NextResponse.json({ error: 'Missing parameters' }, { status: 400 })
+  }
+
+  const supabase = createRouteHandlerClient({ cookies })
+  const {
+    data: { session }
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: userData } = await supabase
+    .from('users')
+    .select('role')
+    .eq('id', session.user.id)
+    .single()
+
+  if (userData?.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { error } = await supabase
+    .from('ideas')
+    .update({ status })
+    .eq('id', ideaId)
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import OrganizationSetup from '@/components/OrganizationSetup'
 import PasswordReset from '@/components/PasswordReset'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import DebugPanel from '@/components/DebugPanel'
+import AdminDashboard from '@/components/AdminDashboard'
 import { supabase } from '@/lib/supabase'
 
 export default function HomePage() {
@@ -222,6 +223,14 @@ export default function HomePage() {
               </div>
               <div className="flex items-center space-x-4">
                 <span className="text-sm text-gray-700">{user.email}</span>
+                {userOrganization?.role === 'admin' && (
+                  <button
+                    onClick={() => setCurrentView('admin')}
+                    className="btn-secondary"
+                  >
+                    Admin
+                  </button>
+                )}
                 <button
                   onClick={signOut}
                   className="btn-secondary"
@@ -250,6 +259,10 @@ export default function HomePage() {
                 onCreateNew={handleCreateProject}
                 onViewProject={handleViewProject}
               />
+            )}
+
+            {currentView === 'admin' && userOrganization && (
+              <AdminDashboard organizationId={userOrganization.organization_id!} />
             )}
 
             {currentView === 'create' && (

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+import { Database } from '@/lib/supabase'
+import { ResponsiveContainer, ScatterChart, Scatter, XAxis, YAxis, Tooltip } from 'recharts'
+
+interface AdminDashboardProps {
+  organizationId: string
+}
+
+export default function AdminDashboard({ organizationId }: AdminDashboardProps) {
+  const [users, setUsers] = useState<Database['public']['Tables']['users']['Row'][]>([])
+  const [projects, setProjects] = useState<any[]>([])
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [newCategory, setNewCategory] = useState('')
+  const [categories, setCategories] = useState<string[]>([])
+
+  useEffect(() => {
+    loadUsers()
+    loadProjects()
+    loadCategories()
+  }, [])
+
+  const loadUsers = async () => {
+    const { data } = await supabase
+      .from('users')
+      .select('*')
+      .eq('organization_id', organizationId)
+    if (data) setUsers(data)
+  }
+
+  const loadProjects = async () => {
+    const { data } = await supabase
+      .from('ideas')
+      .select('id,title,roi_summaries(irr,npv)')
+      .eq('organization_id', organizationId)
+    if (data) {
+      setProjects(
+        data.map((p: any) => ({
+          id: p.id,
+          title: p.title,
+          irr: p.roi_summaries?.[0]?.irr ?? 0,
+          npv: p.roi_summaries?.[0]?.npv ?? 0
+        }))
+      )
+    }
+  }
+
+  const loadCategories = async () => {
+    const { data } = await supabase
+      .from('project_categories')
+      .select('name')
+      .eq('organization_id', organizationId)
+    if (data) setCategories(data.map(c => c.name))
+  }
+
+  const inviteUser = async () => {
+    if (!inviteEmail) return
+    setLoading(true)
+    const res = await fetch('/api/invite-user', {
+      method: 'POST',
+      body: JSON.stringify({ email: inviteEmail, organizationId })
+    })
+    setLoading(false)
+    if (res.ok) {
+      setInviteEmail('')
+      loadUsers()
+      alert('Invitation sent')
+    } else {
+      const j = await res.json()
+      alert(j.error || 'Failed to invite')
+    }
+  }
+
+  const deleteUser = async (id: string) => {
+    if (!confirm('Delete this user?')) return
+    await fetch('/api/delete-user', {
+      method: 'POST',
+      body: JSON.stringify({ userId: id })
+    })
+    loadUsers()
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold">Organization Users</h2>
+
+      <div className="flex space-x-2 items-center">
+        <input
+          className="input-field"
+          type="email"
+          placeholder="user@example.com"
+          value={inviteEmail}
+          onChange={e => setInviteEmail(e.target.value)}
+        />
+        <button onClick={inviteUser} className="btn-primary" disabled={loading}>
+          Invite
+        </button>
+      </div>
+
+      <ul className="divide-y divide-gray-200">
+        {users.map(u => (
+          <li key={u.id} className="py-2 flex justify-between">
+            <span>{u.email}</span>
+            <button onClick={() => deleteUser(u.id)} className="text-red-600 text-sm">Delete</button>
+          </li>
+        ))}
+      </ul>
+
+      <h2 className="text-2xl font-bold pt-8">Project Categories</h2>
+      <div className="flex space-x-2 items-center mb-4">
+        <input
+          className="input-field"
+          type="text"
+          placeholder="New category"
+          value={newCategory}
+          onChange={e => setNewCategory(e.target.value)}
+        />
+        <button
+          onClick={async () => {
+            if (!newCategory) return
+            await supabase.from('project_categories').insert({ name: newCategory, organization_id: organizationId })
+            setNewCategory('')
+            loadCategories()
+          }}
+          className="btn-primary"
+        >
+          Add
+        </button>
+      </div>
+      <ul className="list-disc pl-5">
+        {categories.map(c => (
+          <li key={c}>{c}</li>
+        ))}
+      </ul>
+
+      <h2 className="text-2xl font-bold pt-8">Project ROI</h2>
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <ScatterChart>
+            <XAxis dataKey="npv" name="NPV" />
+            <YAxis dataKey="irr" name="IRR" tickFormatter={v => `${(v*100).toFixed(1)}%`} />
+            <Tooltip formatter={(value: any) => typeof value === 'number' ? value.toFixed(2) : value} />
+            <Scatter data={projects} fill="#8884d8" />
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ProductIdeaForm.tsx
+++ b/src/components/ProductIdeaForm.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
+import { supabase } from '@/lib/supabase'
+import { useAppStore } from '@/lib/store'
 
 const productIdeaSchema = z.object({
   title: z.string().min(1, 'Title is required').max(100, 'Title must be less than 100 characters'),
@@ -22,27 +24,23 @@ interface ProductIdeaFormProps {
   isLoading?: boolean
 }
 
-const PRODUCT_CATEGORIES = [
-  'Electronics',
-  'Software',
-  'Hardware',
-  'Consumer Goods',
-  'Industrial',
-  'Healthcare',
-  'Automotive',
-  'Aerospace',
-  'Food & Beverage',
-  'Fashion',
-  'Home & Garden',
-  'Sports & Recreation',
-  'Education',
-  'Finance',
-  'Other'
-]
-
 export default function ProductIdeaForm({ onComplete, initialData, isLoading = false }: ProductIdeaFormProps) {
   const [currentStep, setCurrentStep] = useState(1)
   const totalSteps = 3
+  const [categories, setCategories] = useState<string[]>([])
+  const { userOrganization } = useAppStore()
+
+  useEffect(() => {
+    const loadCategories = async () => {
+      if (!userOrganization?.organization_id) return
+      const { data } = await supabase
+        .from('project_categories')
+        .select('name')
+        .eq('organization_id', userOrganization.organization_id)
+      if (data) setCategories(data.map(c => c.name))
+    }
+    loadCategories()
+  }, [userOrganization])
 
   const {
     register,
@@ -167,7 +165,7 @@ export default function ProductIdeaForm({ onComplete, initialData, isLoading = f
                 className={`input-field ${errors.category ? 'border-danger-500' : ''}`}
               >
                 <option value="">Select a category</option>
-                {PRODUCT_CATEGORIES.map((category) => (
+                {categories.map((category) => (
                   <option key={category} value={category}>
                     {category}
                   </option>

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -21,6 +21,7 @@ interface ProjectWithROI {
   title: string
   description: string
   category: string
+  status: string
   positioning_statement: string
   required_attributes: string
   competitor_overview: string
@@ -416,6 +417,36 @@ export default function ProjectDashboard({ onCreateNew, onViewProject }: Project
                     <span>Created {new Date(project.created_at).toLocaleDateString()}</span>
                     <span className="text-primary-600 hover:text-primary-700">View Details →</span>
                   </div>
+                  {userRole === 'admin' && project.status === 'pending' && (
+                    <div className="flex space-x-2 mt-2">
+                      <button
+                        onClick={async (e) => {
+                          e.preventDefault()
+                          await fetch('/api/update-idea-status', {
+                            method: 'POST',
+                            body: JSON.stringify({ ideaId: project.id, status: 'approved' })
+                          })
+                          loadProjects()
+                        }}
+                        className="btn-primary btn-sm"
+                      >
+                        Approve
+                      </button>
+                      <button
+                        onClick={async (e) => {
+                          e.preventDefault()
+                          await fetch('/api/update-idea-status', {
+                            method: 'POST',
+                            body: JSON.stringify({ ideaId: project.id, status: 'archived' })
+                          })
+                          loadProjects()
+                        }}
+                        className="btn-secondary btn-sm"
+                      >
+                        Archive
+                      </button>
+                    </div>
+                  )}
                 </div>
               </Link>
             )

--- a/src/lib/roi-calculations.ts
+++ b/src/lib/roi-calculations.ts
@@ -57,39 +57,34 @@ export function calculateNPV(cashFlows: CashFlow[], discountRate: number = 0.10)
  * @returns IRR as decimal (e.g., 0.15 for 15%)
  */
 export function calculateIRR(
-  cashFlows: CashFlow[], 
-  maxIterations: number = 100, 
+  cashFlows: CashFlow[],
+  maxIterations: number = 100,
   tolerance: number = 0.0001
 ): number {
-  if (cashFlows.length === 0) return 0;
-  
-  let guess = 0.1; // Start with 10%
-  
+  if (cashFlows.length === 0) return 0
+
+  // Work with monthly rate
+  let rate = 0.01
+
   for (let i = 0; i < maxIterations; i++) {
-    const npv = calculateNPV(cashFlows, guess);
-    
+    const npv = cashFlows.reduce((sum, flow, idx) => {
+      return sum + flow.netCashFlow / Math.pow(1 + rate, idx)
+    }, 0)
+
     if (Math.abs(npv) < tolerance) {
-      return guess;
+      return Math.pow(1 + rate, 12) - 1
     }
-    
-    // Calculate derivative (simplified)
-    const derivative = cashFlows.reduce((sum, flow, month) => {
-      const discountFactor = Math.pow(1 + guess, month);
-      return sum - (flow.netCashFlow * month) / (discountFactor * (1 + guess));
-    }, 0);
-    
-    if (Math.abs(derivative) < tolerance) {
-      break; // Avoid division by zero
-    }
-    
-    guess = guess - npv / derivative;
-    
-    // Keep guess reasonable
-    if (guess < -0.99) guess = -0.99;
-    if (guess > 10) guess = 10;
+
+    const derivative = cashFlows.reduce((sum, flow, idx) => {
+      return sum - (idx * flow.netCashFlow) / Math.pow(1 + rate, idx + 1)
+    }, 0)
+
+    if (Math.abs(derivative) < tolerance) break
+
+    rate = rate - npv / derivative
   }
-  
-  return guess;
+
+  return Math.pow(1 + rate, 12) - 1
 }
 
 /**

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { User } from '@supabase/supabase-js'
 import { supabase } from './supabase'
 
-export type AppView = 'dashboard' | 'create' | 'view' | 'org-setup' | 'auth'
+export type AppView = 'dashboard' | 'create' | 'view' | 'org-setup' | 'admin' | 'auth'
 
 export interface UserOrganization {
   organization_id: string | null

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -36,6 +36,7 @@ export type Database = {
           full_name: string
           organization_id: string
           role: 'admin' | 'member'
+          is_active: boolean
           created_at: string
         }
         Insert: {
@@ -44,6 +45,7 @@ export type Database = {
           full_name: string
           organization_id: string
           role?: 'admin' | 'member'
+          is_active?: boolean
           created_at?: string
         }
         Update: {
@@ -52,6 +54,7 @@ export type Database = {
           full_name?: string
           organization_id?: string
           role?: 'admin' | 'member'
+          is_active?: boolean
           created_at?: string
         }
       }
@@ -62,6 +65,7 @@ export type Database = {
           title: string
           description: string
           category: string
+          status: 'pending' | 'approved' | 'archived'
           positioning_statement: string
           required_attributes: string
           competitor_overview: string
@@ -74,6 +78,7 @@ export type Database = {
           title: string
           description: string
           category: string
+          status?: 'pending' | 'approved' | 'archived'
           positioning_statement: string
           required_attributes: string
           competitor_overview: string
@@ -86,6 +91,7 @@ export type Database = {
           title?: string
           description?: string
           category?: string
+          status?: 'pending' | 'approved' | 'archived'
           positioning_statement?: string
           required_attributes?: string
           competitor_overview?: string
@@ -201,6 +207,26 @@ export type Database = {
           created_at?: string
         }
       }
+      project_categories: {
+        Row: {
+          id: string
+          organization_id: string
+          name: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          organization_id: string
+          name: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          organization_id?: string
+          name?: string
+          created_at?: string
+        }
+      }
     }
   }
-} 
+}

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+export const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey)


### PR DESCRIPTION
## Summary
- allow service role usage via `SUPABASE_SERVICE_ROLE_KEY`
- extend database for project categories, idea status and active users
- create Supabase admin client and new API routes
- add admin dashboard UI with user, category and ROI management
- support admin view navigation
- fix IRR calculation for monthly periods
- load project categories dynamically when creating ideas

## Testing
- `npm run type-check`
- `npm run lint` *(fails: prompts for interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6863452d9a508330b17c2bc07455ebf8