### PR TITLE
Fix build type error and remove external font dependency

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,7 @@
 import React from 'react'
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import './globals.css'
 import ErrorBoundary from '@/components/ErrorBoundary'
-
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: 'Product ROI Tool',
@@ -18,7 +15,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body>
         <ErrorBoundary>
           {children}
         </ErrorBoundary>

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -176,21 +176,27 @@ export default function ProjectDashboard({ onCreateNew, onViewProject }: Project
     const matchesCategory = !categoryFilter || project.category === categoryFilter
     
     // Map database fields to ROIMetrics interface
-    const roiMetrics = project.roi_summary ? {
-      npv: project.roi_summary.npv || 0,
-      irr: project.roi_summary.irr || 0,
-      breakEvenMonth: project.roi_summary.break_even_month || 0,
-      paybackPeriod: project.roi_summary.payback_period || 0,
-      totalRevenue: 0, // Not stored in database, default to 0
-      totalCosts: 0    // Not stored in database, default to 0
-    } : {
-      npv: 0,
-      irr: 0,
-      breakEvenMonth: 0,
-      paybackPeriod: 0,
-      totalRevenue: 0,
-      totalCosts: 0
-    }
+    const roiMetrics = project.roi_summary
+      ? {
+          npv: project.roi_summary.npv || 0,
+          irr: project.roi_summary.irr || 0,
+          breakEvenMonth: project.roi_summary.break_even_month || 0,
+          paybackPeriod: project.roi_summary.payback_period || 0,
+          totalRevenue: 0, // Not stored in database, default to 0
+          totalCosts: 0, // Not stored in database, default to 0
+          contributionMarginPerUnit: 0,
+          profitPerUnit: 0,
+        }
+      : {
+          npv: 0,
+          irr: 0,
+          breakEvenMonth: 0,
+          paybackPeriod: 0,
+          totalRevenue: 0,
+          totalCosts: 0,
+          contributionMarginPerUnit: 0,
+          profitPerUnit: 0,
+        }
     
     const matchesStatus = !statusFilter || getROIStatus(roiMetrics) === statusFilter
     
@@ -348,21 +354,27 @@ export default function ProjectDashboard({ onCreateNew, onViewProject }: Project
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredProjects.map((project) => {
             // Map database fields to ROIMetrics interface for status calculation
-            const roiMetrics = project.roi_summary ? {
-              npv: project.roi_summary.npv || 0,
-              irr: project.roi_summary.irr || 0,
-              breakEvenMonth: project.roi_summary.break_even_month || 0,
-              paybackPeriod: project.roi_summary.payback_period || 0,
-              totalRevenue: 0, // Not stored in database, default to 0
-              totalCosts: 0    // Not stored in database, default to 0
-            } : {
-              npv: 0,
-              irr: 0,
-              breakEvenMonth: 0,
-              paybackPeriod: 0,
-              totalRevenue: 0,
-              totalCosts: 0
-            }
+            const roiMetrics = project.roi_summary
+              ? {
+                  npv: project.roi_summary.npv || 0,
+                  irr: project.roi_summary.irr || 0,
+                  breakEvenMonth: project.roi_summary.break_even_month || 0,
+                  paybackPeriod: project.roi_summary.payback_period || 0,
+                  totalRevenue: 0, // Not stored in database, default to 0
+                  totalCosts: 0, // Not stored in database, default to 0
+                  contributionMarginPerUnit: 0,
+                  profitPerUnit: 0,
+                }
+              : {
+                  npv: 0,
+                  irr: 0,
+                  breakEvenMonth: 0,
+                  paybackPeriod: 0,
+                  totalRevenue: 0,
+                  totalCosts: 0,
+                  contributionMarginPerUnit: 0,
+                  profitPerUnit: 0,
+                }
             
             const status = getROIStatus(roiMetrics)
 


### PR DESCRIPTION
## Summary
- map all `ROIMetrics` fields when filtering projects
- update card ROI metrics mapping in project list
- use default fonts instead of downloading from Google Fonts

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_6864302bb8a48330a13929b087ed8615