### PR TITLE
Add database management CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ python scripts/invite_user.py user@example.com tempPassword ORGANIZATION_ID
 The script creates the user, assigns them to the specified organization and out
 puts an invite link they can use to finish the sign‑up process.
 
+
+### Database Utility Script
+
+A helper CLI at `scripts/db_cli.py` can apply or reset the database schema. It reads `SUPABASE_DB_URL` for the connection string.
+
+```bash
+# Apply the schema
+python scripts/db_cli.py apply
+
+# Reset RLS policies
+python scripts/db_cli.py reset
+```
+
 ## Deployment
 
 The application can be deployed to Vercel, Netlify, or any other Next.js-compatible platform.

--- a/scripts/db_cli.py
+++ b/scripts/db_cli.py
@@ -1,0 +1,57 @@
+import os
+from pathlib import Path
+import click
+import psycopg
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+SCHEMA_SQL = BASE_DIR / "database" / "schema.sql"
+RESET_SQL = BASE_DIR / "database" / "reset-schema.sql"
+
+DB_URL = os.getenv("SUPABASE_DB_URL")
+
+if not DB_URL:
+    raise SystemExit("SUPABASE_DB_URL environment variable is required")
+
+
+def run_sql(path: Path):
+    sql = path.read_text()
+    with psycopg.connect(DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+        conn.commit()
+
+
+@click.group()
+def cli():
+    """Utility commands for managing the Supabase database."""
+    pass
+
+
+@cli.command()
+def apply():
+    """Apply the main database schema."""
+    click.echo(f"Running schema from {SCHEMA_SQL}...")
+    run_sql(SCHEMA_SQL)
+    click.echo("Schema applied successfully.")
+
+
+@cli.command()
+def reset():
+    """Reset RLS policies using reset-schema.sql."""
+    click.echo(f"Running reset script {RESET_SQL}...")
+    run_sql(RESET_SQL)
+    click.echo("Reset complete.")
+
+
+@cli.command()
+@click.argument("file", type=click.Path(exists=True))
+def exec(file):
+    """Execute an arbitrary SQL file."""
+    path = Path(file)
+    click.echo(f"Executing {path}...")
+    run_sql(path)
+    click.echo("Execution complete.")
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- add `db_cli.py` for running schema and reset scripts
- document usage of the new CLI in README

## Testing
- `npm ci`
- `npm run lint` *(fails: interactive ESLint setup)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6864afded72483308673649f92bcc2b8