### PR TITLE
Add anonymous idea submission form

### DIFF
--- a/database/create-idea-submissions-table.sql
+++ b/database/create-idea-submissions-table.sql
@@ -1,0 +1,36 @@
+-- Create the idea_submissions table for anonymous submissions
+-- This table is separate from the ideas table to keep anonymous submissions distinct
+
+CREATE TABLE IF NOT EXISTS idea_submissions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    category TEXT NOT NULL,
+    positioning_statement TEXT NOT NULL,
+    required_attributes TEXT NOT NULL,
+    competitor_overview TEXT NOT NULL,
+    submitter_email TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Create indexes for better performance
+CREATE INDEX IF NOT EXISTS idx_idea_submissions_organization_id ON idea_submissions(organization_id);
+CREATE INDEX IF NOT EXISTS idx_idea_submissions_created_at ON idea_submissions(created_at);
+
+-- Enable RLS
+ALTER TABLE idea_submissions ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies for idea_submissions
+CREATE POLICY "Anyone can submit ideas" ON idea_submissions
+    FOR INSERT WITH CHECK ( true );
+
+CREATE POLICY "Org users can view submissions" ON idea_submissions
+    FOR SELECT USING (
+        organization_id = public.get_organization_id_for_current_user()
+    );
+
+CREATE POLICY "Admins can delete submissions" ON idea_submissions
+    FOR DELETE USING (
+        organization_id = public.get_organization_id_for_current_user() AND public.is_admin_for_current_user()
+    ); 

--- a/database/fix-submission-rls.sql
+++ b/database/fix-submission-rls.sql
@@ -1,0 +1,26 @@
+-- Fix for public submission form - allow anyone to view organizations by invite code
+-- This policy allows unauthenticated users to look up organizations when they have an invite code
+-- which is necessary for the public submission form to work
+
+CREATE POLICY "Anyone can view organizations by invite code" ON organizations
+    FOR SELECT USING (
+        invite_code IS NOT NULL
+    );
+
+-- Note: This policy allows viewing any organization that has an invite code
+-- The application logic in the submit page will only use the id and name fields
+-- and will only proceed if the organization is found by the specific invite code
+
+-- Fix for public submission form - allow anyone to view categories for organizations with invite codes
+-- This policy allows unauthenticated users to view product categories when they have a valid invite code
+-- which is necessary for the public submission form to work
+
+CREATE POLICY "Anyone can view categories for organizations with invite codes" ON project_categories
+    FOR SELECT USING (
+        organization_id IN (
+            SELECT id FROM organizations WHERE invite_code IS NOT NULL
+        )
+    );
+
+-- Note: This policy allows viewing categories for any organization that has an invite code
+-- The application logic will filter categories by the specific organization found by invite code 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -28,6 +28,20 @@ CREATE TABLE if not exists project_categories (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+-- Table for anonymous idea submissions collected via public form
+CREATE TABLE IF NOT EXISTS idea_submissions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    category TEXT NOT NULL,
+    positioning_statement TEXT NOT NULL,
+    required_attributes TEXT NOT NULL,
+    competitor_overview TEXT NOT NULL,
+    submitter_email TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
 -- Create ideas table
 CREATE TABLE if not exists ideas (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -147,6 +161,7 @@ $$;
 ALTER TABLE organizations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE users ENABLE ROW LEVEL SECURITY;
 ALTER TABLE project_categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE idea_submissions ENABLE ROW LEVEL SECURITY;
 ALTER TABLE ideas ENABLE ROW LEVEL SECURITY;
 ALTER TABLE sales_forecasts ENABLE ROW LEVEL SECURITY;
 ALTER TABLE activity_rates ENABLE ROW LEVEL SECURITY;
@@ -212,6 +227,20 @@ CREATE POLICY "Admins can update categories" ON project_categories
     );
 
 CREATE POLICY "Admins can delete categories" ON project_categories
+    FOR DELETE USING (
+        organization_id = public.get_organization_id_for_current_user() AND public.is_admin_for_current_user()
+    );
+
+-- RLS Policies for idea_submissions
+CREATE POLICY "Anyone can submit ideas" ON idea_submissions
+    FOR INSERT WITH CHECK ( true );
+
+CREATE POLICY "Org users can view submissions" ON idea_submissions
+    FOR SELECT USING (
+        organization_id = public.get_organization_id_for_current_user()
+    );
+
+CREATE POLICY "Admins can delete submissions" ON idea_submissions
     FOR DELETE USING (
         organization_id = public.get_organization_id_for_current_user() AND public.is_admin_for_current_user()
     );
@@ -550,4 +579,5 @@ CREATE INDEX idx_labor_entries_activity_id ON labor_entries(activity_id);
 CREATE INDEX idx_roi_summaries_idea_id ON roi_summaries(idea_id);
 CREATE INDEX idx_organizations_invite_code ON organizations(invite_code);
 CREATE INDEX idx_project_categories_org_id ON project_categories(organization_id);
+CREATE INDEX idx_idea_submissions_org_id ON idea_submissions(organization_id);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "next": "^15.3.4",
         "nodemailer": "^7.0.4",
         "postcss": "^8.4.32",
+        "qrcode": "^1.5.4",
         "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2295,6 +2296,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -2382,6 +2392,51 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -2699,6 +2754,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -2763,6 +2827,12 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -3822,6 +3892,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -5350,6 +5429,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -5373,7 +5461,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5464,6 +5551,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5613,6 +5709,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/qrcode.react": {
@@ -5825,6 +5938,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -5991,6 +6119,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
@@ -7137,6 +7271,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
@@ -7291,6 +7431,12 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
@@ -7301,6 +7447,113 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "next": "^15.3.4",
         "nodemailer": "^7.0.4",
         "postcss": "^8.4.32",
+        "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.48.2",
@@ -35,6 +36,7 @@
       },
       "devDependencies": {
         "@types/nodemailer": "^6.4.17",
+        "@types/qrcode": "^1.5.5",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
         "eslint": "^8.56.0",
@@ -1265,6 +1267,16 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.5.tgz",
+      "integrity": "sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
@@ -5601,6 +5613,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next": "^15.3.4",
     "nodemailer": "^7.0.4",
     "postcss": "^8.4.32",
+    "qrcode.react": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.48.2",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@types/nodemailer": "^6.4.17",
+    "@types/qrcode": "^1.5.5",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "eslint": "^8.56.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next": "^15.3.4",
     "nodemailer": "^7.0.4",
     "postcss": "^8.4.32",
+    "qrcode": "^1.5.4",
     "qrcode.react": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/app/api/submission-qr/route.ts
+++ b/src/app/api/submission-qr/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import QRCode from 'qrcode'
+import { getSubmissionUrl } from '@/lib/getSubmissionUrl'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const code = searchParams.get('code')
+  if (!code) {
+    return NextResponse.json({ error: 'Missing code' }, { status: 400 })
+  }
+
+  const url = getSubmissionUrl(code)
+  try {
+    const dataUrl = await QRCode.toDataURL(url)
+    const base64 = dataUrl.split(',')[1]
+    return new NextResponse(Buffer.from(base64, 'base64'), {
+      headers: { 'Content-Type': 'image/png' }
+    })
+  } catch (err) {
+    return NextResponse.json({ error: 'Failed to generate QR' }, { status: 500 })
+  }
+}

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -1543,6 +1543,8 @@ function ROICalculator({ forecasts, costEstimates, roiSummary, onSave, saving, s
     return x0
   }
   const irr = cashFlows.length > 1 ? calcIRR(cashFlows.map(cf => cf.total)) : 0
+  // Cap IRR at 3 (300%) for display
+  const irrCapped = Math.min(irr, 3)
   // Break-even month
   let cumulative = 0, breakEvenMonth = 0
   for (let i = 0; i < cashFlows.length; i++) {
@@ -1584,7 +1586,7 @@ function ROICalculator({ forecasts, costEstimates, roiSummary, onSave, saving, s
   const handleSave = () => {
     onSave({
       npv: Number(npv.toFixed(2)),
-      irr: Number(irr.toFixed(4)),
+      irr: Math.min(Number(irr.toFixed(4)), 3), // Cap at 3 (300%) before saving
       break_even_month: breakEvenMonth,
       payback_period: Number(paybackPeriod.toFixed(2)),
       contribution_margin_per_unit: Number(contributionMarginPerUnit.toFixed(2)),
@@ -1603,7 +1605,7 @@ function ROICalculator({ forecasts, costEstimates, roiSummary, onSave, saving, s
           </div>
           <div className="bg-gray-50 rounded-lg p-4 text-center">
             <div className="text-xs text-gray-500">IRR</div>
-            <div className="text-xl font-bold text-cyan-700">{(irr * 100).toFixed(1)}%</div>
+            <div className="text-xl font-bold text-cyan-700">{irr > 3 ? '300%+' : (irrCapped * 100).toFixed(1) + '%'}</div>
           </div>
           <div className="bg-gray-50 rounded-lg p-4 text-center">
             <div className="text-xs text-gray-500">Break Even</div>

--- a/src/app/submit/[code]/page.tsx
+++ b/src/app/submit/[code]/page.tsx
@@ -1,31 +1,72 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 import ProductIdeaForm from '@/components/ProductIdeaForm'
 
-export default function SubmitPage({ params }: { params: { code: string } }) {
+export default function SubmitPage() {
+  const params = useParams<{ code: string }>()
+  const code = params?.code
   const [orgId, setOrgId] = useState<string | null>(null)
   const [orgName, setOrgName] = useState<string>('')
   const [submitted, setSubmitted] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    if (!code) {
+      setLoading(false)
+      setError('No invite code provided')
+      return
+    }
+    
     const loadOrg = async () => {
-      const { data } = await supabase
-        .from('organizations')
-        .select('id,name')
-        .eq('invite_code', params.code)
-        .single()
-      if (data) {
-        setOrgId(data.id)
-        setOrgName(data.name)
+      try {
+        const { data, error: dbError } = await supabase
+          .from('organizations')
+          .select('id,name')
+          .eq('invite_code', code)
+          .single()
+        
+        if (dbError) {
+          console.error('Database error:', dbError)
+          setError(`Database error: ${dbError.message}`)
+          setLoading(false)
+          return
+        }
+        
+        if (data) {
+          setOrgId(data.id)
+          setOrgName(data.name)
+        } else {
+          setError('Invalid invite code - no organization found')
+        }
+      } catch (err) {
+        console.error('Unexpected error:', err)
+        setError('An unexpected error occurred')
+      } finally {
+        setLoading(false)
       }
     }
+    
     loadOrg()
-  }, [params.code])
+  }, [code])
+
+  if (loading) {
+    return <div className="p-6">Loading...</div>
+  }
+
+  if (error) {
+    return <div className="p-6 text-red-600">Error: {error}</div>
+  }
+
+  if (!code) {
+    return <div className="p-6">Invalid submission link.</div>
+  }
 
   if (!orgId) {
-    return <div className="p-6">Invalid submission link.</div>
+    return <div className="p-6">Invalid submission link - organization not found.</div>
   }
 
   if (submitted) {

--- a/src/app/submit/[code]/page.tsx
+++ b/src/app/submit/[code]/page.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+import ProductIdeaForm from '@/components/ProductIdeaForm'
+
+export default function SubmitPage({ params }: { params: { code: string } }) {
+  const [orgId, setOrgId] = useState<string | null>(null)
+  const [orgName, setOrgName] = useState<string>('')
+  const [submitted, setSubmitted] = useState(false)
+
+  useEffect(() => {
+    const loadOrg = async () => {
+      const { data } = await supabase
+        .from('organizations')
+        .select('id,name')
+        .eq('invite_code', params.code)
+        .single()
+      if (data) {
+        setOrgId(data.id)
+        setOrgName(data.name)
+      }
+    }
+    loadOrg()
+  }, [params.code])
+
+  if (!orgId) {
+    return <div className="p-6">Invalid submission link.</div>
+  }
+
+  if (submitted) {
+    return <div className="p-6">Thank you for your idea!</div>
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">Submit an Idea for {orgName}</h1>
+      <ProductIdeaForm
+        organizationId={orgId}
+        includeEmail
+        onComplete={async (data) => {
+          await supabase.from('idea_submissions').insert({
+            ...data,
+            organization_id: orgId
+          })
+          setSubmitted(true)
+        }}
+      />
+    </div>
+  )
+}

--- a/src/lib/debug-db.ts
+++ b/src/lib/debug-db.ts
@@ -117,4 +117,33 @@ export async function createTestUserProfile(userId: string) {
     console.error('Error in createTestUserProfile:', error)
     return false
   }
+}
+
+export async function debugOrganizations() {
+  console.log('=== Debugging Organizations ===')
+  
+  // Check all organizations
+  const { data: orgs, error: orgError } = await supabase
+    .from('organizations')
+    .select('id, name, invite_code, created_at')
+    .order('created_at', { ascending: false })
+  
+  if (orgError) {
+    console.error('Error fetching organizations:', orgError)
+    return
+  }
+  
+  console.log('All organizations:', orgs)
+  
+  // Check specific invite code
+  const testCode = 'ORG-C236D9BA'
+  const { data: specificOrg, error: specificError } = await supabase
+    .from('organizations')
+    .select('id, name, invite_code')
+    .eq('invite_code', testCode)
+    .single()
+  
+  console.log(`Looking for invite code "${testCode}":`, { data: specificOrg, error: specificError })
+  
+  return { orgs, specificOrg }
 } 

--- a/src/lib/getSubmissionUrl.ts
+++ b/src/lib/getSubmissionUrl.ts
@@ -1,4 +1,4 @@
 export function getSubmissionUrl(inviteCode: string) {
-  const base = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  const base = process.env.NEXT_PUBLIC_SITE_URL || 'https://roi-calculator-green.vercel.app/'
   return `${base}/submit/${inviteCode}`
 }

--- a/src/lib/getSubmissionUrl.ts
+++ b/src/lib/getSubmissionUrl.ts
@@ -1,0 +1,4 @@
+export function getSubmissionUrl(inviteCode: string) {
+  const base = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  return `${base}/submit/${inviteCode}`
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -315,6 +315,44 @@ export type Database = {
           created_at?: string
         }
       }
+      idea_submissions: {
+        Row: {
+          id: string
+          organization_id: string
+          title: string
+          description: string
+          category: string
+          positioning_statement: string
+          required_attributes: string
+          competitor_overview: string
+          submitter_email: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          organization_id: string
+          title: string
+          description: string
+          category: string
+          positioning_statement: string
+          required_attributes: string
+          competitor_overview: string
+          submitter_email?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          organization_id?: string
+          title?: string
+          description?: string
+          category?: string
+          positioning_statement?: string
+          required_attributes?: string
+          competitor_overview?: string
+          submitter_email?: string | null
+          created_at?: string
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- enable public idea submissions in the DB
- expose submission form at `/submit/[code]`
- generate QR codes for submission links
- show submitted ideas and shareable link in the admin dashboard
- extend product form with optional email field

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6865935b2e5483308a1152d6fce43799