### PR TITLE
Improve auth state management

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import type { Metadata } from 'next'
 import './globals.css'
 import ErrorBoundary from '@/components/ErrorBoundary'
+import AuthProvider from '@/components/AuthProvider'
 
 export const metadata: Metadata = {
   title: 'Product ROI Tool',
@@ -17,7 +18,9 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <ErrorBoundary>
-          {children}
+          <AuthProvider>
+            {children}
+          </AuthProvider>
         </ErrorBoundary>
       </body>
     </html>

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,0 +1,19 @@
+'use client'
+import { useEffect, useRef } from 'react'
+import { useAppStore } from '@/lib/store'
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const { initializeAuth, setupAuthListener, authChecked } = useAppStore()
+  const initialized = useRef(false)
+
+  useEffect(() => {
+    if (initialized.current) return
+    initialized.current = true
+    setupAuthListener()
+    if (!authChecked) {
+      initializeAuth()
+    }
+  }, [authChecked, initializeAuth, setupAuthListener])
+
+  return <>{children}</>
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
+import { useAppStore } from '@/lib/store'
 import { formatCurrency, formatPercentage, getROIStatus } from '@/lib/roi-calculations'
 import { Database } from '@/lib/supabase'
 import LoadingSpinner from '@/components/LoadingSpinner'
@@ -43,10 +44,13 @@ export default function ProjectDashboard({ onCreateNew, onViewProject }: Project
   const [organizationInviteCode, setOrganizationInviteCode] = useState<string | null>(null)
   const [showInviteCode, setShowInviteCode] = useState(false)
 
+  const { user, isAuthenticated } = useAppStore()
+
   useEffect(() => {
+    if (!isAuthenticated || !user) return
     loadProjects()
     checkUserRole()
-  }, [])
+  }, [isAuthenticated, user])
 
   // Add click outside handler for invite code dropdown
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add `AuthProvider` to centralize auth initialization and state updates
- wrap app layout with AuthProvider so auth status loads on every page
- reload project dashboard data only when authenticated
- load product details and related data only after auth state is ready

## Testing
- `npm run lint`
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6865cbc8a1dc8330aef3eedc50deff43