### PR TITLE
Refine submission form layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -100,7 +100,7 @@
   }
   
   .form-section {
-    @apply space-y-6;
+    @apply space-y-6 sm:space-y-8;
   }
   
   .form-group {

--- a/src/app/submit/[code]/page.tsx
+++ b/src/app/submit/[code]/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 import ProductIdeaForm from '@/components/ProductIdeaForm'
+import SiteHeader from '@/components/SiteHeader'
+import SiteFooter from '@/components/SiteFooter'
 
 export default function SubmitPage() {
   const params = useParams<{ code: string }>()
@@ -74,19 +76,23 @@ export default function SubmitPage() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto p-6">
-      <h1 className="text-2xl font-bold mb-4">Submit an Idea for {orgName}</h1>
-      <ProductIdeaForm
-        organizationId={orgId}
-        includeEmail
-        onComplete={async (data) => {
-          await supabase.from('idea_submissions').insert({
-            ...data,
-            organization_id: orgId
-          })
-          setSubmitted(true)
-        }}
-      />
+    <div className="min-h-screen flex flex-col">
+      <SiteHeader />
+      <main className="flex-grow max-w-2xl mx-auto p-4 sm:p-6">
+        <h1 className="text-2xl font-bold mb-4">Submit an Idea for {orgName}</h1>
+        <ProductIdeaForm
+          organizationId={orgId}
+          includeEmail
+          onComplete={async (data) => {
+            await supabase.from('idea_submissions').insert({
+              ...data,
+              organization_id: orgId
+            })
+            setSubmitted(true)
+          }}
+        />
+      </main>
+      <SiteFooter />
     </div>
   )
 }

--- a/src/components/ProductIdeaForm.tsx
+++ b/src/components/ProductIdeaForm.tsx
@@ -100,35 +100,35 @@ export default function ProductIdeaForm({ onComplete, initialData, isLoading = f
   }
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <div className="max-w-4xl mx-auto px-4 sm:px-0">
       {/* Progress Bar */}
-      <div className="mb-8">
-        <div className="flex justify-center gap-x-12 max-w-xl mx-auto">
+      <div className="mb-6 sm:mb-8">
+        <div className="flex justify-center gap-x-8 sm:gap-x-12 max-w-xl mx-auto">
           {[1, 2, 3].map((step) => (
             <div key={step} className="flex items-center">
               <div className={`flex items-center justify-center w-8 h-8 rounded-full border-2 ${
-                step <= currentStep 
-                  ? 'bg-primary-600 border-primary-600 text-white' 
+                step <= currentStep
+                  ? 'bg-primary-600 border-primary-600 text-white'
                   : 'border-gray-300 text-gray-500'
               }`}>
                 {step}
               </div>
               {step < 3 && (
-                <div className={`w-16 h-1 mx-2 ${
+                <div className={`w-12 sm:w-16 h-1 mx-2 ${
                   step < currentStep ? 'bg-primary-600' : 'bg-gray-300'
                 }`} />
               )}
             </div>
           ))}
         </div>
-        <div className="flex justify-center gap-x-32 mt-2 text-sm text-gray-600 max-w-xl mx-auto">
+        <div className="flex justify-center gap-x-8 sm:gap-x-32 mt-2 text-sm text-gray-600 max-w-xl mx-auto">
           <span>Basic Info</span>
           <span>Positioning</span>
           <span>Requirements</span>
         </div>
       </div>
 
-      <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-8">
+      <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-6 sm:space-y-8">
         {/* Step 1: Basic Information */}
         {currentStep === 1 && (
           <div className="form-section">

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function SiteFooter() {
+  return (
+    <footer className="bg-white border-t border-gray-200 mt-12">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 text-center text-sm text-gray-500">
+        © {new Date().getFullYear()} Product ROI Tool
+      </div>
+    </footer>
+  )
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function SiteHeader() {
+  return (
+    <header className="bg-white shadow-sm border-b border-gray-200">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+        <h1 className="text-lg sm:text-xl font-semibold text-gray-900">Product ROI Tool</h1>
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add basic header and footer components
- use header/footer on anonymous idea submission page
- tweak ProductIdeaForm spacing and responsiveness
- adjust global form section spacing

## Testing
- `npm run type-check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865fe927b30833092142a1ff936940f